### PR TITLE
Added confidence intervals to prediction

### DIFF
--- a/functions.R
+++ b/functions.R
@@ -65,7 +65,7 @@ projSimple<-function(rawN, rawTime, inWindow=10){
   lnN <- log(rawN[ss])
   tIn <- rawTime[ss]
   mFit <- lm(lnN~tIn)
-  extFit <- predict(mFit, newdata = list(tIn = x), interval = "prediction")
+  extFit <- predict(mFit, newdata = list(tIn = x), interval = "confidence")
   y <- exp(extFit)
   list(x=x, y=y)
 }

--- a/server.R
+++ b/server.R
@@ -86,10 +86,10 @@ shinyServer(function(input, output) {
     yI <- tsSub(tsI,tsI$Country.Region %in% input$countryFinder)
     dRate <- detRate(yI, yD)
     lDat <- projSimple(yA, dates)
-    nowThen <- c(tail(yA[!is.na(yA)], 1), tail(lDat$y[,"fit"],1))
+    nowThen <- c(tail(yA[!is.na(yA)], 1), tail(lDat$y[,"lwr"],1), tail(lDat$y[,"upr"],1))
     nowThenTrue <- nowThen/dRate
     outTab<-rbind(nowThen, nowThenTrue)
-    colnames(outTab)<-c("Now", "In 10 days")
+    colnames(outTab)<-c("Now", "In 10 days (min)", "In 10 days (max)")
     row.names(outTab)<-c("Confirmed cases", "Possible true number")
     outTab
   }, rownames = TRUE, digits = 0)


### PR DESCRIPTION
- It's my first time with Shiny Apps and my first time collaborating over GitHub, so I started with an easy idea :)
  - I added confidence intervals to the predicted value for 10 days, so now instead of just showing one predicted value in 10 days, it would show a "min" predicted and a "max" predicted

- There is a conceptual thing I'm trying to wrap my head around: since the evolution of the number of cases is exponential, in small countries (e.g. Switzerland) this simple model predicts that most (and often all) of the population will get infected. Now, this is quite improbable. Ben, do you know any way to add a "dumping" factor (i.e. find a way to maximize the possible number of predicted cases)? I will read some literature today and see if I can find something.
  - (I will add an issue about this, but mention it here too)