### PR TITLE
Added growth rate

### DIFF
--- a/functions.R
+++ b/functions.R
@@ -22,12 +22,19 @@
 
 ## function definitions
 
+# growth rate
+growthRate <- function(cases, inWindow=10){
+  nn <- length(cases)
+  ss <- (nn - inWindow + 1):nn
+  rate <- numeric(length(ss))
+  rate[ss] <- (cases[ss] - cases[ss-1]) / cases[ss-1]
+}
+
 # aggregates results to country
 countryAgg<-function(x){
   xSelect<-x[, dCols]
   aggregate(xSelect, by = list(Country = x$Country.Region), FUN = sum)
 }
-
 
 # calculates the curve flatenning index.
   # it is the second derivative of logA wrt t (the change in growth rate) divided by first differential (the current growth rate).
@@ -52,9 +59,6 @@ detRate<-function(infd, deaths, cfr = 0.025, ttd=17, window=5){
   if (out>1) out<-1
   out
 }
-
-
-
 
 # Simple projection based on growth over last inWindow days
   # returns extended plotting data

--- a/functions.R
+++ b/functions.R
@@ -30,6 +30,7 @@ growthRate <- function(cases, inWindow=10){
   rate[ss] <- (cases[ss] - cases[ss-1]) / cases[ss-1]
 }
 
+
 # aggregates results to country
 countryAgg<-function(x){
   xSelect<-x[, dCols]

--- a/getData.R
+++ b/getData.R
@@ -55,4 +55,5 @@ matA<-matI - matD - matR
 tsA <- cbind(tsI[,!dCols], matA) # active cases
 
 tsACountry <- countryAgg(tsA) # aggregated to country
+tsICountry <- countryAgg(tsI) 
 

--- a/getData.R
+++ b/getData.R
@@ -55,5 +55,4 @@ matA<-matI - matD - matR
 tsA <- cbind(tsI[,!dCols], matA) # active cases
 
 tsACountry <- countryAgg(tsA) # aggregated to country
-tsICountry <- countryAgg(tsI) 
 

--- a/server.R
+++ b/server.R
@@ -83,7 +83,7 @@ shinyServer(function(input, output) {
     nowThen <- c(tail(yA[!is.na(yA)], 1), tail(lDat$y[,"lwr"],1), tail(lDat$y[,"upr"],1))
     nowThenTrue <- nowThen/dRate
     nowThen <- c(nowThen[1], paste(round(nowThen[2],0), "-", round(nowThen[3],0)))
-    nowThenTrue <- c(nowThenTrue[1], paste(round(nowThenTrue[2],0), "-", round(nowThenTrue[3],0)))
+    nowThenTrue <- c(round(nowThenTrue[1],0), paste(round(nowThenTrue[2],0), "-", round(nowThenTrue[3],0)))
     outTab<-rbind(nowThen, nowThenTrue)
     colnames(outTab)<-c("Now", "In 10 days (min-max)")
     row.names(outTab)<-c("Confirmed", "Possible")
@@ -116,5 +116,21 @@ shinyServer(function(input, output) {
            lty = 1, 
            col = clrs,
            bty = "n")
+  })
+  
+  output$growthrate <- renderPlot({
+    pDat <- subset(tsICountry, tsICountry$Country %in% input$countryGrowthRate)
+    gRate <- as.matrix(growthRate(pDat))
+    clrs<-hcl.colors(length(input$countryGrowthRate))
+    dates10 <- dates[(length(pDat)-10+1):length(pDat)]
+    counts <- table(gRate)
+    barplot(gRate,
+            main="Growth rate",
+            xlab="Date", 
+            ylab="Growth rate",
+            beside=TRUE,
+            col = clrs,
+            legend = input$countryGrowthRate,
+            args.legend = list(bty = "n", x = "top"))
   })
 })

--- a/server.R
+++ b/server.R
@@ -118,8 +118,8 @@ shinyServer(function(input, output) {
            bty = "n")
   })
   
-  output$growthrate <- renderPlot({
-    pDat <- subset(tsICountry, tsICountry$Country %in% input$countryGrowthRate)
+  output$growthRate <- renderPlot({
+    pDat <- subset(tsACountry, tsACountry$Country %in% input$countryGrowthRate)
     gRate <- as.matrix(growthRate(pDat))
     clrs<-hcl.colors(length(input$countryGrowthRate))
     dates10 <- dates[(length(pDat)-10+1):length(pDat)]
@@ -131,6 +131,6 @@ shinyServer(function(input, output) {
             beside=TRUE,
             col = clrs,
             legend = input$countryGrowthRate,
-            args.legend = list(bty = "n", x = "top"))
+            args.legend = list(bty = "n", x = "topleft"))
   })
 })

--- a/ui.R
+++ b/ui.R
@@ -81,6 +81,22 @@ shinyUI(fluidPage(
                         a("here.", href = "https://blphillipsresearch.wordpress.com/2020/03/12/coronavirus-forecast/", target="_blank")))
                  )
                )
-      )
+      ),
+      tabPanel("Growth rate",
+               # Sidebar
+               sidebarLayout(
+                 sidebarPanel(
+                   titlePanel("Location selector"),
+                   checkboxGroupInput(inputId = "countryGrowthRate",
+                                      label = "Select Country/Region:",
+                                      choices = ddReg,
+                                      selected = ddNames[1:3])
+                 ),
+                 mainPanel(
+                   plotOutput("growthrate"),
+                   h5("This is the growth rate of the number of cases for the last 10 days.")
+                 )
+               )
+               )
   )
 ))

--- a/ui.R
+++ b/ui.R
@@ -93,7 +93,7 @@ shinyUI(fluidPage(
                                       selected = ddNames[1:3])
                  ),
                  mainPanel(
-                   plotOutput("growthrate"),
+                   plotOutput("growthRate"),
                    h5("This is the growth rate of the number of cases for the last 10 days.")
                  )
                )


### PR DESCRIPTION
I added the growth rate to the app. Growth rate was calculated as (#ActiveToday - #ActiveYesterday) / #ActiveYesterday. Feel free to change it if you have some other measure of growth rate in mind (e.g. with respect to total infections and not only active?).

I see only an issue with the legend: when checking only China, you can see that growth rate is negative over the last 10 days (which makes sense), but when adding Italy, Italy looks negative. It's clearly a mismatch between legend and data, but I didn't find a way to fix it.