### PR TITLE
Added deaths to new cases plot, single y-axis.

### DIFF
--- a/app.R
+++ b/app.R
@@ -241,23 +241,39 @@ server <- function(input, output, session) {
 ##### New cases ##### 
   output$newCases <- renderPlotly({
     if (input$countryFinder != '') {
-      yI <- yfCast()$yI
-      yA <- yfCast()$yA
-      newCases <- diff(yI)
-      newCases <- data.frame(dates = as.Date(names(newCases), format = "%m.%d.%y"), newCases)
-      fig <- plot_ly(newCases, 
-                     x = ~dates, 
-                     y = ~newCases, 
-                     type = "bar", 
-                     showlegend = FALSE, 
-                     name = "New cases",
-                     hoverinfo = "text+name", 
-                     text = paste(format(newCases$dates, "%b %d"), format(round(newCases$newCases, 0), big.mark = ",")))
-      fig <- fig %>% layout(xaxis = list(range = plotRange(),
-                                        title = list(text = "Date")),
-                            yaxis = list(title = list(text = "Number of new cases"))
-                      ) %>%
-                      config(displayModeBar = FALSE)
+      yI <- yfCast()$yI # Infected
+      yD <- yfCast()$yD # Deaths
+      clrDark<-"#273D6E"
+      clrLight<-"#B2C3D5"
+      clrOrange<-"#FF7F0E"
+      # Calculate new cases
+      newCases <- diff(yI) 
+      # Format the date
+      newCases <- data.frame(dates = as.Date(names(newCases), format = "%m.%d.%y"), newCases) 
+      
+      # Calculate daily deaths
+      dailyDeaths <- diff(yD) 
+      
+      fig <- plot_ly(newCases, type = "bar", mode = "none") %>%
+        add_trace(y = ~newCases,
+                  x = ~dates, 
+                  name = "new cases", 
+                  marker = list(color = clrOrange), 
+                  text = paste(format(newCases$dates, "%b %d"),format(newCases$newCases, big.mark = ",")),
+                  hoverinfo = "text+name"
+        ) %>%
+        add_trace(y = ~dailyDeaths,
+                  x = ~dates,
+                  name = "daily deaths",
+                  marker = list(color = clrDark),
+                  text = paste(format(newCases$dates, "%b %d"),format(dailyDeaths, big.mark = ",")),
+                  hoverinfo = "text+name" 
+        ) %>%
+        layout(xaxis = list(range = plotRange(),
+                            title = list(text = "Date")),
+               yaxis = list(title = list(text = "Number of new cases")),
+               barmode = 'group') %>%
+        config(displayModeBar = FALSE)      
     }
   })
   


### PR DESCRIPTION
This could be another option for adding deaths to new cases #77 
This keeps just one Y-axis, as is number of people for both, puts the number of deaths next to the number of new cases, show the true proportion on the figure; the consideration is that when the numbers of deaths are low (less than 3%) it 'fades'.

Looks like this, for Australia.
![AddDtoAOneYA01 2020-04-24 17-02-11](https://user-images.githubusercontent.com/6541729/80447465-cbf44000-895c-11ea-9d16-c23d9fe23cdd.png)
