### PR TITLE
Check cumulants mk ii

### DIFF
--- a/functions.R
+++ b/functions.R
@@ -64,6 +64,8 @@ activeCases <- function(infections, deaths, recoveries){
   infections <- infections[order(infections$Country.Region, infections$Province.State),]
   deaths <- deaths[order(deaths$Country.Region, deaths$Province.State),]
   recoveries <- recoveries[order(recoveries$Country.Region, recoveries$Province.State),]
+  orderTest <- sum(!(infections$Country.Region == deaths$Country.Region & infections$Country.Region == recoveries$Country.Region)) != 0
+  if (orderTest) stop("Region labels do not align")
   # subset to case data
   infMat <- infections[,ssCol]
   deathMat <- deaths[,ssCol]

--- a/getData.R
+++ b/getData.R
@@ -115,8 +115,6 @@ if (test1 & test2 & test3 & test4){
   infSub   <- subset(timeSeriesInfections, timeSeriesInfections$Country.Region %in% recMissing)
   deathSub <- subset(timeSeriesDeaths,     timeSeriesDeaths$Country.Region     %in% recMissing)
   recSub   <- recLag(infSub, deathSub, active = FALSE)
-
-
   # Merge US, Canada, India estimated recoveries on to known recoveries
   timeSeriesRecoveries <- rbind(subset(timeSeriesRecoveries, !(timeSeriesRecoveries$Country.Region %in% recMissing)) , recSub)
   
@@ -132,7 +130,15 @@ if (test1 & test2 & test3 & test4){
   timeSeriesInfections <- timeSeriesInfections[cumSub,]
   timeSeriesDeaths <- timeSeriesDeaths[cumSub,]
   timeSeriesRecoveries <- timeSeriesRecoveries[cumSub,]
+  rm(checkI, checkD, cumSub)
   
+  # find large errors in recoveries cumulant and replace with reclag generated values
+  checkR <- cumulantCheck(timeSeriesRecoveries)
+  infSub   <- subset(timeSeriesInfections, !checkR)
+  deathSub <- subset(timeSeriesDeaths, !checkR)
+  recSub   <- recLag(infSub, deathSub, active = FALSE)
+  timeSeriesRecoveries[!checkR, ] <- recSub
+  rm(infSub, deathSub, recSub, checkR) # tidy up
   
   ## standardise
   # Standardise dataframes and compute active cases

--- a/getData.R
+++ b/getData.R
@@ -122,28 +122,21 @@ if (test1 & test2 & test3 & test4){
   #sum(!(table(timeSeriesRecoveries$Country.Region) == table(timeSeriesInfections$Country.Region)))
   rm(infSub, deathSub, recSub) # tidy up
   
-  # exclude data where there are large errors in the infection and death cumulants
-  checkI <- cumulantCheck(timeSeriesInfections)
-  checkD <- cumulantCheck(timeSeriesDeaths)
-  cumSub <- checkI & checkD
-  print(cbind(timeSeriesInfections[!cumSub, 1:2], checkI = checkI[!cumSub], checkD = checkD[!cumSub]))
-  timeSeriesInfections <- timeSeriesInfections[cumSub,]
-  timeSeriesDeaths <- timeSeriesDeaths[cumSub,]
-  timeSeriesRecoveries <- timeSeriesRecoveries[cumSub,]
-  rm(checkI, checkD, cumSub)
-  
-  # find large errors in recoveries cumulant and replace with reclag generated values
-  checkR <- cumulantCheck(timeSeriesRecoveries)
-  infSub   <- subset(timeSeriesInfections, !checkR)
-  deathSub <- subset(timeSeriesDeaths, !checkR)
-  recSub   <- recLag(infSub, deathSub, active = FALSE)
-  timeSeriesRecoveries[!checkR, ] <- recSub
-  rm(infSub, deathSub, recSub, checkR) # tidy up
-  
   ## standardise
   # Standardise dataframes and compute active cases
   std <- activeCases(timeSeriesInfections, timeSeriesDeaths, timeSeriesRecoveries)
   
+  # exclude data where there are large errors in the infection and death cumulants
+  checkI <- cumulantCheck(std$tsI)
+  checkD <- cumulantCheck(std$tsD)
+  cumSub <- checkI & checkD
+  print(cbind(std$tsI[!cumSub, 1:2], checkI = checkI[!cumSub], checkD = checkD[!cumSub]))
+  std$tsI <- std$tsI[cumSub,]
+  std$tsD <- std$tsD[cumSub,]
+  std$tsR <- std$tsR[cumSub,]
+  std$tsA <- std$tsA[cumSub,]
+  rm(checkI, checkD, cumSub)
+
   
   # Create a list to hold all data
   available_countries <- c("Australia","China", "Canada", "US", "India") # countries available for drill-down

--- a/getData.R
+++ b/getData.R
@@ -124,12 +124,11 @@ if (test1 & test2 & test3 & test4){
   #sum(!(table(timeSeriesRecoveries$Country.Region) == table(timeSeriesInfections$Country.Region)))
   rm(infSub, deathSub, recSub) # tidy up
   
-  # exclude data where there are large errors in the cumulant
+  # exclude data where there are large errors in the infection and death cumulants
   checkI <- cumulantCheck(timeSeriesInfections)
   checkD <- cumulantCheck(timeSeriesDeaths)
-  checkR <- cumulantCheck(timeSeriesRecoveries)
-  cumSub <- checkI & checkD & checkR
-  print(cbind(timeSeriesInfections[!cumSub, 1:2], checkI = checkI[!cumSub], checkD = checkD[!cumSub], checkR = checkR[!cumSub]))
+  cumSub <- checkI & checkD
+  print(cbind(timeSeriesInfections[!cumSub, 1:2], checkI = checkI[!cumSub], checkD = checkD[!cumSub]))
   timeSeriesInfections <- timeSeriesInfections[cumSub,]
   timeSeriesDeaths <- timeSeriesDeaths[cumSub,]
   timeSeriesRecoveries <- timeSeriesRecoveries[cumSub,]

--- a/getData.R
+++ b/getData.R
@@ -173,7 +173,7 @@ if (test1 & test2 & test3 & test4){
   
   ## Define menus
   # get region names with 20 or more cases as of yesterday
-  ddNames <- timeSeriesActive$Region[timeSeriesActive[[ncol(timeSeriesActive)-1]]>19]
+  ddNames <- timeSeriesInfections$Region[timeSeriesInfections[[ncol(timeSeriesInfections)-1]]>19]
   
   ddReg <- ddNames
   names(ddReg) <- ddNames
@@ -227,7 +227,7 @@ if (test1 & test2 & test3 & test4){
     
     ## Define menus
     # get region names with 20 or more cases as of yesterday
-    ddNames <- timeSeriesActive$Region[timeSeriesActive[[ncol(timeSeriesActive)-1]]>19]
+    ddNames <- timeSeriesInfections$Region[timeSeriesInfections[[ncol(timeSeriesInfections)-1]]>19]
     ddReg        <- ddNames
     names(ddReg) <- ddNames
     


### PR DESCRIPTION
Corrects two bugs. 
First (only 6 hours old, thankfully) caused disordering of some data, leading to incorrect active cases in 71 regions.
Second was thresholding menu inclusion on active cases rather than cumulative infections (so regions where caseload dropped below 20 were being excluded).