### PR TITLE
Get india mk ii

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@ Otherwise, go into getData.R, set `server <- FALSE`.  This will then obtain data
 `Rscript getData.R`
 
 Which will take about 10 minutes to run.  This script will generate a directory structure inside /dat (if that structure doesn't already exist) and populate it with data required by the app.
+
+In subsequent days, to update data after this initial run you will need to run both `getData.R` and `getIndia.R` separately.

--- a/app.R
+++ b/app.R
@@ -62,6 +62,8 @@ server <- function(input, output, session) {
   observe({
     # change data inputs
     list2env(dataList[[input$global_or_country]], envir = parent.env(environment()))
+    output$asOfDate <- renderText(format(dates[length(dates)], "%d %B %Y"))
+    
 
     if (input$global_or_country == 'Global') {
       updateSelectizeInput(session, "countryFinder",  choices = ddReg)

--- a/base.html
+++ b/base.html
@@ -54,7 +54,7 @@
       <div role="main">
 <br><br><br><br>
         <h1 class="center" style="padding-top:40px;">{{ textOutput(outputId = "country_name_in_header") }} Coronavirus 10-day forecast</h1>
-        <h2>As of  {{ format(dates[length(dates)], "%d %B %Y") }} </h2>
+        <h2>As of  {{ textOutput(outputId = "asOfDate", container = span) }} </h2>
         <p>Provides estimates of COVID-19 growth rate, detection, and near-future case load in each country, updated daily, based on global data collated by John Hopkins University</p>
 
 <script>

--- a/getData.R
+++ b/getData.R
@@ -194,7 +194,9 @@ if (test1 & test2 & test3 & test4){
   
   for(focusCountry in available_countries) {
     
+    if (focusCountry=="India") next # do India independently, in getIndia.R
     print(focusCountry)
+    
     # set dataframes back to standards
     tsI <- std$tsI
     tsD <- std$tsD
@@ -243,5 +245,8 @@ if (test1 & test2 & test3 & test4){
   }
   
   save(dataList, file = "dat/dataList.RData")
+  
+  # run getIndia.R
+  system("Rscript getIndia.R", wait = TRUE)
   
 } else { print('there was an error!') } # end of first data test if statement (test1, test2) ...need to add our else notification here

--- a/getData.R
+++ b/getData.R
@@ -2,7 +2,12 @@
 ##
 ## Script name: getData.R
 ##
-## Purpose of script: Scrape data from gitHub repository established to track nCov20
+## Purpose of script: 
+## 1. Get data from JHU;
+## 2. Build directory structure for all state-level data;
+## 3. If dataList doesn't already exist, create it
+## 4. Build global dataset and state-level for countries available in JHU dataset
+## 5. If dataList doesn't exist run retrieval of state-level data for other (non-JHU) datasets.
 ##
 ## Author: Ben Phillips
 ##
@@ -73,7 +78,7 @@ test2 <- nrow(timeSeriesDeathsUS)==nrow(timeSeriesInfectionsUS) & nrow(timeSerie
   # NAs anywhere in the data
 test3 <- (sum(is.na(timeSeriesInfections))+sum(is.na(timeSeriesDeaths))+sum(is.na(timeSeriesRecoveries))+sum(is.na(timeSeriesInfectionsUS))+sum(is.na(timeSeriesDeathsUS)))==0
 
-if (test1 & test2 & test3 & test4){
+if (test1 & test2 & test3){
 
   # Merge US data with global dataframes
   timeSeriesInfections <- rbind(subset(timeSeriesInfections, timeSeriesInfections$Country.Region != "US"), timeSeriesInfectionsUS)
@@ -127,6 +132,7 @@ if (test1 & test2 & test3 & test4){
   
   
   ###### GLOBAL ######
+  print("Global") # report to console
   
   timeSeriesInfections <- regionAgg(std$tsI, regionCol = std$tsI$Country.Region, regionName = "Region") # aggregated to country
   timeSeriesDeaths     <- regionAgg(std$tsD, regionCol = std$tsD$Country.Region, regionName = "Region") 

--- a/getData.R
+++ b/getData.R
@@ -198,6 +198,8 @@ if (test1 & test2 & test3 & test4){
   ###### LOCAL ######
   
   for(focusCountry in available_countries) {
+    # check country directory exists
+    dir.create(paste0("dat/", focusCountry), showWarnings = FALSE) # if the directory doesn't exist, create it.
     
     if (focusCountry=="India") next # do India independently, in getIndia.R
     print(focusCountry)
@@ -232,7 +234,6 @@ if (test1 & test2 & test3 & test4){
     names(ddReg) <- ddNames
     
     ## write data caches out
-    dir.create(paste0("dat/", focusCountry), showWarnings = FALSE) # if the directory doesn't exist, create it.
     save(ddReg, ddNames, file = paste0("dat/",focusCountry,"/menuData.RData"))
     save(timeSeriesInfections, timeSeriesDeaths, timeSeriesRecoveries, timeSeriesActive, dates, file = paste0("dat/",focusCountry,"/cacheData.RData"))
     

--- a/getData.R
+++ b/getData.R
@@ -138,10 +138,15 @@ if (test1 & test2 & test3 & test4){
   rm(checkI, checkD, cumSub)
 
   
-  # Create a list to hold all data
+  # Open dataList object, or create it
   available_countries <- c("Australia","China", "Canada", "US", "India") # countries available for drill-down
-  dataList <- vector(mode = "list", length = length(available_countries)+1)
-  names(dataList) <- c("Global", available_countries)
+  if (file.exists("dat/dataList.RData")) {
+    load("dat/dataList.RData")
+  } else {
+    dataList <- vector(mode = "list", length = length(available_countries)+1)
+    names(dataList) <- c("Global", available_countries)
+  }
+  
   
   
   ###### GLOBAL ######

--- a/getIndia.R
+++ b/getIndia.R
@@ -26,7 +26,6 @@ source('functions.R')
 ## ---------------------------
 
 focusCountry <- "India" # define country string
-print(focusCountry) # report to console
 
 tsConfIndia  <- "https://raw.githubusercontent.com/vipinbhatnagar/covid19/master/confirmed.csv"
 tsDeathIndia <- "https://raw.githubusercontent.com/vipinbhatnagar/covid19/master/deaths.csv"
@@ -45,6 +44,8 @@ test3 <- (sum(is.na(timeSeriesInfections))+sum(is.na(timeSeriesDeaths)))==0
 
 if (test1 & test2 & test3) {
 
+  print(focusCountry) # report to console
+  
   ## get Date range 
   dCols<-dateCols(timeSeriesInfections)
   dates<-as.Date(colnames(timeSeriesInfections)[dCols], format = "%m.%d.%y")

--- a/getIndia.R
+++ b/getIndia.R
@@ -1,0 +1,102 @@
+## ---------------------------
+##
+## Script name: getIndia.R
+##
+## Purpose of script: to get India data from Vipin/Jyoti's repo, independently from JHU process
+##
+## Author: Ben Phillips
+##
+## Date Created: 2020-05-04
+##
+## Email: phillipsb@unimelb.edu.au
+##
+## ---------------------------
+##
+## Notes:
+##   
+##
+## --------------------------
+## load up the packages we will need 
+
+## ---------------------------
+
+## load up our functions into memory
+source('functions.R')
+
+## ---------------------------
+
+focusCountry <- "India" # define country string
+print(focusCountry) # report to console
+
+tsConfIndia  <- "https://raw.githubusercontent.com/vipinbhatnagar/covid19/master/confirmed.csv"
+tsDeathIndia <- "https://raw.githubusercontent.com/vipinbhatnagar/covid19/master/deaths.csv"
+
+
+timeSeriesInfections <-loadData(tsConfIndia)
+timeSeriesDeaths     <-loadData(tsDeathIndia)
+
+rm(tsConfIndia, tsDeathIndia)
+
+## get Date range 
+dCols<-dateCols(timeSeriesInfections)
+dates<-as.Date(colnames(timeSeriesInfections)[dCols], format = "%m.%d.%y")
+
+## generate recovery data
+timeSeriesRecoveries   <- recLag(timeSeriesInfections, timeSeriesDeaths, active = FALSE)
+
+
+# Standardise dataframes and compute active cases
+std <- activeCases(timeSeriesInfections, timeSeriesDeaths, timeSeriesRecoveries)
+
+# exclude data where there are large errors in the infection and death cumulants
+checkI <- cumulantCheck(std$tsI)
+checkD <- cumulantCheck(std$tsD)
+cumSub <- checkI & checkD
+print(cbind(std$tsI[!cumSub, 1:2], checkI = checkI[!cumSub], checkD = checkD[!cumSub]))
+tsI <- std$tsI[cumSub,]
+tsD <- std$tsD[cumSub,]
+tsR <- std$tsR[cumSub,]
+tsA <- std$tsA[cumSub,]
+rm(checkI, checkD, cumSub)
+
+# aggregate to region
+tsI <- regionAgg(tsI, regionCol = tsI$Province.State)
+tsD <- regionAgg(tsD, regionCol = tsD$Province.State)
+tsR <- regionAgg(tsR, regionCol = tsR$Province.State)
+tsA <- regionAgg(tsA, regionCol = tsA$Province.State)
+
+timeSeriesInfections <- natAgg(tsI, aggName = paste("National aggregate -", focusCountry))
+timeSeriesDeaths <- natAgg(tsD, aggName = paste("National aggregate -", focusCountry))
+timeSeriesRecoveries <- natAgg(tsR, aggName = paste("National aggregate -", focusCountry))
+timeSeriesActive <- natAgg(tsA, aggName = paste("National aggregate -", focusCountry))
+
+## Define menus
+# get region names with 20 or more cases as of yesterday
+ddNames <- timeSeriesInfections$Region[timeSeriesInfections[[ncol(timeSeriesInfections)-1]]>19]
+ddReg        <- ddNames
+names(ddReg) <- ddNames
+
+## write data caches out
+dir.create(paste0("dat/", focusCountry), showWarnings = FALSE) # if the directory doesn't exist, create it.
+save(ddReg, ddNames, file = paste0("dat/",focusCountry,"/menuData.RData"))
+save(timeSeriesInfections, timeSeriesDeaths, timeSeriesRecoveries, timeSeriesActive, dates, file = paste0("dat/",focusCountry,"/cacheData.RData"))
+
+system(paste("Rscript detection/estGlobalV2.R", focusCountry), wait = TRUE)
+load(paste0("dat/",focusCountry,"/estDeconv.RData"))
+
+# load dataList object
+load("dat/dataList.RData")
+
+# append India data
+dataList[[focusCountry]] <- list(timeSeriesInfections = timeSeriesInfections,
+                                 timeSeriesDeaths = timeSeriesDeaths,
+                                 timeSeriesRecoveries = timeSeriesRecoveries,
+                                 timeSeriesActive = timeSeriesActive,
+                                 dates = dates,
+                                 ddReg = ddReg,
+                                 ddNames = ddNames,
+                                 cumulative.infections = cumulative.infections,
+                                 active.cases = active.cases)
+
+# write datList back out
+save(dataList, file = "dat/dataList.RData")

--- a/getIndia.R
+++ b/getIndia.R
@@ -37,66 +37,76 @@ timeSeriesDeaths     <-loadData(tsDeathIndia)
 
 rm(tsConfIndia, tsDeathIndia)
 
-## get Date range 
-dCols<-dateCols(timeSeriesInfections)
-dates<-as.Date(colnames(timeSeriesInfections)[dCols], format = "%m.%d.%y")
+# test structural integrity of data
+test1 <- nrow(timeSeriesDeaths)==nrow(timeSeriesInfections)
+test2 <- ncol(timeSeriesDeaths)==ncol(timeSeriesInfections)
+# NAs anywhere in the data
+test3 <- (sum(is.na(timeSeriesInfections))+sum(is.na(timeSeriesDeaths)))==0
 
-## generate recovery data
-timeSeriesRecoveries   <- recLag(timeSeriesInfections, timeSeriesDeaths, active = FALSE)
+if (test1 & test2 & test3) {
 
-
-# Standardise dataframes and compute active cases
-std <- activeCases(timeSeriesInfections, timeSeriesDeaths, timeSeriesRecoveries)
-
-# exclude data where there are large errors in the infection and death cumulants
-checkI <- cumulantCheck(std$tsI)
-checkD <- cumulantCheck(std$tsD)
-cumSub <- checkI & checkD
-print(cbind(std$tsI[!cumSub, 1:2], checkI = checkI[!cumSub], checkD = checkD[!cumSub]))
-tsI <- std$tsI[cumSub,]
-tsD <- std$tsD[cumSub,]
-tsR <- std$tsR[cumSub,]
-tsA <- std$tsA[cumSub,]
-rm(checkI, checkD, cumSub)
-
-# aggregate to region
-tsI <- regionAgg(tsI, regionCol = tsI$Province.State)
-tsD <- regionAgg(tsD, regionCol = tsD$Province.State)
-tsR <- regionAgg(tsR, regionCol = tsR$Province.State)
-tsA <- regionAgg(tsA, regionCol = tsA$Province.State)
-
-timeSeriesInfections <- natAgg(tsI, aggName = paste("National aggregate -", focusCountry))
-timeSeriesDeaths <- natAgg(tsD, aggName = paste("National aggregate -", focusCountry))
-timeSeriesRecoveries <- natAgg(tsR, aggName = paste("National aggregate -", focusCountry))
-timeSeriesActive <- natAgg(tsA, aggName = paste("National aggregate -", focusCountry))
-
-## Define menus
-# get region names with 20 or more cases as of yesterday
-ddNames <- timeSeriesInfections$Region[timeSeriesInfections[[ncol(timeSeriesInfections)-1]]>19]
-ddReg        <- ddNames
-names(ddReg) <- ddNames
-
-## write data caches out
-dir.create(paste0("dat/", focusCountry), showWarnings = FALSE) # if the directory doesn't exist, create it.
-save(ddReg, ddNames, file = paste0("dat/",focusCountry,"/menuData.RData"))
-save(timeSeriesInfections, timeSeriesDeaths, timeSeriesRecoveries, timeSeriesActive, dates, file = paste0("dat/",focusCountry,"/cacheData.RData"))
-
-system(paste("Rscript detection/estGlobalV2.R", focusCountry), wait = TRUE)
-load(paste0("dat/",focusCountry,"/estDeconv.RData"))
-
-# load dataList object
-load("dat/dataList.RData")
-
-# append India data
-dataList[[focusCountry]] <- list(timeSeriesInfections = timeSeriesInfections,
-                                 timeSeriesDeaths = timeSeriesDeaths,
-                                 timeSeriesRecoveries = timeSeriesRecoveries,
-                                 timeSeriesActive = timeSeriesActive,
-                                 dates = dates,
-                                 ddReg = ddReg,
-                                 ddNames = ddNames,
-                                 cumulative.infections = cumulative.infections,
-                                 active.cases = active.cases)
-
-# write datList back out
-save(dataList, file = "dat/dataList.RData")
+  ## get Date range 
+  dCols<-dateCols(timeSeriesInfections)
+  dates<-as.Date(colnames(timeSeriesInfections)[dCols], format = "%m.%d.%y")
+  
+  ## generate recovery data
+  timeSeriesRecoveries   <- recLag(timeSeriesInfections, timeSeriesDeaths, active = FALSE)
+  
+  
+  # Standardise dataframes and compute active cases
+  std <- activeCases(timeSeriesInfections, timeSeriesDeaths, timeSeriesRecoveries)
+  
+  # exclude data where there are large errors in the infection and death cumulants
+  checkI <- cumulantCheck(std$tsI)
+  checkD <- cumulantCheck(std$tsD)
+  cumSub <- checkI & checkD
+  print(cbind(std$tsI[!cumSub, 1:2], checkI = checkI[!cumSub], checkD = checkD[!cumSub]))
+  tsI <- std$tsI[cumSub,]
+  tsD <- std$tsD[cumSub,]
+  tsR <- std$tsR[cumSub,]
+  tsA <- std$tsA[cumSub,]
+  rm(checkI, checkD, cumSub)
+  
+  # aggregate to region
+  tsI <- regionAgg(tsI, regionCol = tsI$Province.State)
+  tsD <- regionAgg(tsD, regionCol = tsD$Province.State)
+  tsR <- regionAgg(tsR, regionCol = tsR$Province.State)
+  tsA <- regionAgg(tsA, regionCol = tsA$Province.State)
+  
+  timeSeriesInfections <- natAgg(tsI, aggName = paste("National aggregate -", focusCountry))
+  timeSeriesDeaths <- natAgg(tsD, aggName = paste("National aggregate -", focusCountry))
+  timeSeriesRecoveries <- natAgg(tsR, aggName = paste("National aggregate -", focusCountry))
+  timeSeriesActive <- natAgg(tsA, aggName = paste("National aggregate -", focusCountry))
+  
+  ## Define menus
+  # get region names with 20 or more cases as of yesterday
+  ddNames <- timeSeriesInfections$Region[timeSeriesInfections[[ncol(timeSeriesInfections)-1]]>19]
+  ddReg        <- ddNames
+  names(ddReg) <- ddNames
+  
+  ## write data caches out
+  dir.create(paste0("dat/", focusCountry), showWarnings = FALSE) # if the directory doesn't exist, create it.
+  save(ddReg, ddNames, file = paste0("dat/",focusCountry,"/menuData.RData"))
+  save(timeSeriesInfections, timeSeriesDeaths, timeSeriesRecoveries, timeSeriesActive, dates, file = paste0("dat/",focusCountry,"/cacheData.RData"))
+  
+  system(paste("Rscript detection/estGlobalV2.R", focusCountry), wait = TRUE)
+  load(paste0("dat/",focusCountry,"/estDeconv.RData"))
+  
+  # load dataList object
+  load("dat/dataList.RData")
+  
+  # append India data
+  dataList[[focusCountry]] <- list(timeSeriesInfections = timeSeriesInfections,
+                                   timeSeriesDeaths = timeSeriesDeaths,
+                                   timeSeriesRecoveries = timeSeriesRecoveries,
+                                   timeSeriesActive = timeSeriesActive,
+                                   dates = dates,
+                                   ddReg = ddReg,
+                                   ddNames = ddNames,
+                                   cumulative.infections = cumulative.infections,
+                                   active.cases = active.cases)
+  
+  # write datList back out
+  save(dataList, file = "dat/dataList.RData")
+  
+} else { print('there was an error!') }  


### PR DESCRIPTION
Gets India data as a separate process to retrieval of JHU data.

- Allows different date range between JHU and India datasets

- Allows JHU and India data retrieval to occur at different times

- Allows easy extensibility to other state-level datasets

- Creates all necessary directories and data objects on first run.  Updates data objects thereafter.