### PR TITLE
Cosmetics, reduce the size of header 'Forecast metrics'.

### DIFF
--- a/base.html
+++ b/base.html
@@ -127,7 +127,7 @@ function openTab(evt, tabName) {
         {{ tableOutput(outputId = "tablePredConf") }}
         <p>Active cases are total number of infections minus deaths and recoveries.</p>
         
-        <h3>Forecast metrics:</h3>
+        <h5>Forecast metrics:</h5>
         <div class="center">{{ textOutput(outputId = "forecastMetrics") }}</div>
 
         <fieldset>  


### PR DESCRIPTION
Cosmetic change; I have reduced the size of the 'Forecast metrics' header as is a sub section of 'Active cases', affecting 'In 10 days' calculations.