### PR TITLE
Fix ACT bug

### DIFF
--- a/app.R
+++ b/app.R
@@ -409,12 +409,11 @@ server <- function(input, output, session) {
         paste("Active cases estimated to peak at", format(as.integer(projfCast()$value_at_peak), big.mark=","),"cases on", format(projfCast()$date_at_peak, "%d %B"))
       }
     } else {
-        pDat <- yfCast()$yA
-        doubTime <- round(doubTime(pDat, dates, inWindow = input$fitWinSlider), 1)
+        doubTime <- round(projfCast()$doubling_time, 1)
         if (doubTime > 0) {
-          dTime <- paste("Doubling time is", round(doubTime(pDat, dates, inWindow = input$fitWinSlider), 1), 'days')
+          dTime <- paste("Doubling time is", doubTime, 'days')
         } else {
-          dTime <- paste("Halving time is", -round(doubTime(pDat, dates, inWindow = input$fitWinSlider), 1), 'days')
+          dTime <- paste("Halving time is", -doubTime, 'days')
         }
     }
     }

--- a/functions.R
+++ b/functions.R
@@ -186,12 +186,18 @@ projSimple<-function(rawN, rawTime, inWindow=10, extWindow=10, timeVaryingGrowth
     intercept <- summary(fit_based_on_integers_instead_of_dates)$coefficients[1,1]
     poly1     <- summary(fit_based_on_integers_instead_of_dates)$coefficients[2,1]
     poly2     <- summary(fit_based_on_integers_instead_of_dates)$coefficients[3,1]
-    date_at_peak <- tail(tIn,n=1) + (round(-poly1 / (2*poly2)) - nn)
-    value_at_peak <- exp(intercept)*exp(poly1^2/(2*(-poly2)))*exp(poly2*(poly1/(2*poly2))^2)
-    if (poly2 > 0 | date_at_peak > max(x)) {
-      value_at_peak <- NULL
-    }
-    if (date_at_peak < min(x)){
+    if (poly2 != 0){
+      date_at_peak <- tail(tIn,n=1) + (round(-poly1 / (2*poly2)) - nn)
+      value_at_peak <- exp(intercept)*exp(poly1^2/(2*(-poly2)))*exp(poly2*(poly1/(2*poly2))^2)
+    
+      if (poly2 > 0 | date_at_peak > max(x)) {
+       value_at_peak <- NULL
+      }
+      if (date_at_peak < min(x)){
+        date_at_peak <-NULL
+      }
+    } else if (poly1 == 0 & intercept == 0) {
+      value_at_peak <- NA
       date_at_peak <-NULL
     }
   } else {

--- a/functions.R
+++ b/functions.R
@@ -95,13 +95,6 @@ recLag <- function(infections, deaths, datCols = dateCols(infections), ttr = 22,
   out
 }
 
-# calculates doubling time over the last inWindow days.
-doubTime <- function(cases, time, inWindow = 10){
-  r <- projSimpleSlope(cases, time, inWindow = inWindow)[2]
-  log(2)/r
-}
-
-
 # growth rate
 growthRate <- function(cases, inWindow=10){
   nn <- length(cases)
@@ -177,7 +170,12 @@ projSimple<-function(rawN, rawTime, inWindow=10, extWindow=10, timeVaryingGrowth
   nn <- length(rawN)
   ss <- (nn-inWindow+1):nn
   x <- c(rawTime[ss], rawTime[nn]+1:extWindow)
-  lnN <- log(rawN[ss])
+  if (sum(rawN[ss]==0)>=(length(rawN[ss])-1)){ #if there is one or fewer non-zero data points...
+    yPieces <- rep(0, length(x))
+    y <- data.frame(fit = yPieces, lwr = yPieces, upr = yPieces)
+    return(list(lDat = data.frame(dates = x, y), date_at_peak = NULL, value_at_peak = -99, doubling_time = Inf))
+  }
+  lnN <- log(rawN[ss]) 
   lnN[is.infinite(lnN)]<-NA
   tIn <- rawTime[ss]
   if (timeVaryingGrowth){
@@ -197,33 +195,22 @@ projSimple<-function(rawN, rawTime, inWindow=10, extWindow=10, timeVaryingGrowth
         date_at_peak <-NULL
       }
     } else if (poly1 == 0 & intercept == 0) {
-      value_at_peak <- NA
+      value_at_peak <- -99
       date_at_peak <-NULL
     }
   } else {
     mFit <- lm(lnN~tIn)
+    r <- coefficients(mFit)[2]
+    doubling_time <- log(2)/r
   }
   extFit <- predict(mFit, newdata = list(tIn = x), interval = "confidence")
   y <- exp(extFit)
   if(timeVaryingGrowth) {
     list(lDat = data.frame(dates = x, y), date_at_peak = date_at_peak, value_at_peak = value_at_peak)
   } else {
-    list(lDat = data.frame(dates = x, y))
+    list(lDat = data.frame(dates = x, y), doubling_time = doubling_time)
   }
 
-}
-
-# Simple projection based on growth over last inWindow days
-# returns coefficients
-projSimpleSlope<-function(rawN, rawTime, inWindow=10){
-  nn <- length(rawN)
-  ss <- (nn-inWindow+1):nn
-  x <- c(rawTime[ss], rawTime[nn]+1:inWindow)
-  lnN <- log(rawN[ss])
-  lnN[is.infinite(lnN)]<-NA
-  tIn <- rawTime[ss]
-  mFit <- lm(lnN~tIn)
-  coefficients(mFit)
 }
 
 # to identify the date columns in ts dataframes


### PR DESCRIPTION
Actually a bug about cases going to zero and log transform breaking down.  Rather than add an arbitrary small number to cases, I tried to catch cases where fit data had 1 or fewer non-zero cases.  Slightly more work, but avoids crazy fits on the log scale at small numbers.

Also merged doubling time calculation into projSimple(), so doubTime() and projSimpleSlope() functions were redundant and have been deleted.