### PR TITLE
Fix csv out of order

### DIFF
--- a/createCSV.R
+++ b/createCSV.R
@@ -52,7 +52,8 @@ if (libraryToSourceFrom == 'COVID19') { # covid19datahub.io
   originalData[is.na(originalData)] <- 0 # replace NAs with 0
 }
 
-dates <- unique(originalData$date)
+# some missing values can put the dates out of order.
+dates <- sort(unique(originalData$date))
 seq <- c(1:length(dates))
 
 
@@ -78,26 +79,47 @@ if (updateCSV) {
   dir.create("csvData", showWarnings = FALSE) # if the directory doesn't exist, create it.
 
   #confirmed
+  currentConfirmed <- numeric(length(states))
   dataConfirmed <- originalData %>% select(state, date, cases_total)
   outputConfirmed <- data.frame('Province/State' = states, 'Country/Region' = replicate(length(states),countryName))
   for (value in seq) {
-    outputConfirmed[[format(dates[value], '%-m/%d/%y')]] <- subset(dataConfirmed, dataConfirmed$date == dates[value])$cases_total
+    src_set <- subset(dataConfirmed, dataConfirmed$date == dates[value])
+    if (length(src_set$cases_total) == length(currentConfirmed)) {
+      currentConfirmed <- src_set$cases_total
+    } else {
+      currentConfirmed[(outputConfirmed$state %in% src_set$state)] <- src_set$cases_total
+    }
+    outputConfirmed[[format(dates[value], '%-m/%d/%y')]] <- currentConfirmed
   }
   write.csv(outputConfirmed, paste0('csvData/',countryName, '_confirmed.csv'), quote=FALSE, row.names=FALSE)
 
   #deaths
+  currentDeaths <- numeric(length(states))
   dataDeaths <- originalData %>% select(state, date, deaths_total)
   outputDeaths <- data.frame('Province/State' = states, 'Country/Region' = replicate(length(states),countryName))
   for (value in seq) {
-    outputDeaths[[format(dates[value], '%-m/%d/%y')]] <- subset(dataDeaths, dataDeaths$date == dates[value])$deaths_total
+    src_set <- subset(dataDeaths, dataDeaths$date == dates[value])
+    if (length(src_set$deaths_total) == length(currentDeaths)) {
+      currentDeaths <- src_set$deaths_total
+    } else {
+      currentDeaths[(outputDeaths$state %in% src_set$state)] <- src_set$deaths_total
+    }
+    outputDeaths[[format(dates[value], '%-m/%d/%y')]] <- currentDeaths
   }
   write.csv(outputDeaths, paste0('csvData/',countryName, '_deaths.csv'), quote=FALSE, row.names=FALSE)
 
   #recovered
+  currentRecovered <- numeric(length(states))
   dataRecovered <- originalData %>% select(state, date, recovered_total)
   outputRecovered <- data.frame('Province/State' = states, 'Country/Region' = replicate(length(states),countryName))
   for (value in seq) {
-    outputRecovered[[format(dates[value], '%-m/%d/%y')]] <- subset(dataRecovered, dataRecovered$date == dates[value])$recovered_total
+    src_set <- subset(dataRecovered, dataRecovered$date == dates[value])
+    if (length(src_set$recovered_total) == length(currentRecovered)) {
+      currentRecovered <- src_set$recovered_total
+    } else {
+      currentRecovered[(outputRecovered$state %in% src_set$state)] <- src_set$recovered_total
+    }
+    outputRecovered[[format(dates[value], '%-m/%d/%y')]] <- currentRecovered
   }
   write.csv(outputRecovered, paste0('csvData/',countryName, '_recovered.csv'), quote=FALSE, row.names=FALSE)
 

--- a/functions.R
+++ b/functions.R
@@ -129,10 +129,14 @@ activeCases <- function(infections, deaths, recoveries){
 # Adjusts cumulative infections to get active cases
   # cumulative infections and deaths, ttr = time to recovery
   # if active = false, returns recoveries rather than active cases
-recLag <- function(infections, deaths, datCols = dateCols(infections), ttr = 22, active = TRUE){
+recLag <- function(infections, deaths, datCols = dateCols(infections), ttr = 22, active = TRUE, ignore.deaths=FALSE){
   matI<-as.matrix(infections[, datCols])
   matD<-as.matrix(deaths[, datCols])
-  matA<-matI-matD #remove deaths
+  if (ignore.deaths) {
+    matA <- matI #calculate 'removed' instead of 'recovered'
+  } else {
+    matA<-matI-matD #remove deaths
+  }
   if (length(ttr)==1){
     matR <- cbind(matrix(0, nrow = nrow(matA), ncol = 22), matA[, -((ncol(matA)-21):ncol(matA)), drop = FALSE]) # "recovered"
   } else {
@@ -143,6 +147,9 @@ recLag <- function(infections, deaths, datCols = dateCols(infections), ttr = 22,
     }
   }
   matA <- matA - matR
+  if (ignore.deaths) {
+    matR <- matR - matD #recovered = 'removed' minus deaths
+  }
   if (active) {
     out <- data.frame(infections[,!datCols], matA) # "active" cases
   } else {

--- a/getDataGeneral.R
+++ b/getDataGeneral.R
@@ -26,19 +26,19 @@ runDeconvolution <- function(countryName, deconvProcess = 1) {
 }
 
 
-getDataCovid19datahub <- function(countryName) {
+getDataCovid19datahub <- function(countryName, ignore.deaths=FALSE) {
   getDataGeneral(countryName, paste0('./csvData/',countryName,'_confirmed.csv'),
                                                      paste0('./csvData/',countryName,'_deaths.csv'),
-                                                     paste0('./csvData/',countryName,'_recovered.csv'), TRUE)
+                                                     paste0('./csvData/',countryName,'_recovered.csv'), TRUE, ignore.deaths=ignore.deaths)
 }
 
-getDataCovid19datahubWithoutRecovered <- function(countryName) {
+getDataCovid19datahubWithoutRecovered <- function(countryName, ignore.deaths=FALSE) {
   getDataGeneral(countryName, paste0('./csvData/',countryName,'_confirmed.csv'),
                                                      paste0('./csvData/',countryName,'_deaths.csv'),
-                                                     '', TRUE)
+                                                     '', TRUE, ignore.deaths=ignore.deaths)
 }
 
-getDataGeneral <- function(countryName, inputConfirmed, inputDeaths, inputRecovered = '', verbose){
+getDataGeneral <- function(countryName, inputConfirmed, inputDeaths, inputRecovered = '', verbose, ignore.deaths=FALSE){
 
 
 t1 = Sys.time()
@@ -79,7 +79,7 @@ if (countryName == 'Global') {
 
     timeSeriesRecoveries <- subset(timeSeriesRecoveries, !(timeSeriesRecoveries$Country.Region %in% countriesToGenerateWithRecLag))
     timeSeriesRecoveries <- rbind(timeSeriesRecoveries, recLag(subset(timeSeriesInfections, timeSeriesInfections$Country.Region %in% countriesToGenerateWithRecLag),
-                                                             subset(timeSeriesDeaths,     timeSeriesDeaths$Country.Region     %in% countriesToGenerateWithRecLag), active=FALSE))
+                                                             subset(timeSeriesDeaths,     timeSeriesDeaths$Country.Region     %in% countriesToGenerateWithRecLag), active=FALSE, ignore.deaths=ignore.deaths))
 
     timeSeriesRecoveries$Province.State <- NULL
   }  
@@ -95,7 +95,7 @@ if (countryName == 'Global') {
     timeSeriesRecoveries <- subset(timeSeriesRecoveries, timeSeriesRecoveries$Country.Region == countryName)
     if (countryName == 'Australia') {# fix the ruby princess issue and hard code ignore NSW recovery data
       timeSeriesRecoveries <- fixNSW(timeSeriesRecoveries) 
-      tempRec <- recLag(infections = timeSeriesInfections, deaths = timeSeriesDeaths, active = FALSE)
+      tempRec <- recLag(infections = timeSeriesInfections, deaths = timeSeriesDeaths, active = FALSE, ignore.deaths=ignore.deaths)
       timeSeriesRecoveries[timeSeriesRecoveries$Province.State == "New South Wales",] <- tempRec[tempRec$Province.State=="New South Wales",]
     }
     timeSeriesRecoveries$Country.Region <- NULL
@@ -157,7 +157,7 @@ if (noErrors) {
 
   ## generate recovery data if it doesn't already exist
   if (!inputRecoveredSupplied) {
-    timeSeriesRecoveries <- recLag(timeSeriesInfections, timeSeriesDeaths, active = FALSE)
+    timeSeriesRecoveries <- recLag(timeSeriesInfections, timeSeriesDeaths, active = FALSE, ignore.deaths=ignore.deaths)
   }
 
   # Standardise dataframes and compute active cases

--- a/getPeru.R
+++ b/getPeru.R
@@ -1,3 +1,3 @@
 source('getDataGeneral.R')
 
-getDataCovid19datahubWithoutRecovered('Peru')
+getDataCovid19datahubWithoutRecovered('Peru', ignore.deaths=TRUE)


### PR DESCRIPTION
Some countries not updating because source data include dates out of order. Fixed by sorting data before saving as CSV. Also modified Peru to ignore deaths when calculating recoveries and active cases to prevent the problem of negative active cases after missing deaths data corrects itself in June 2021.